### PR TITLE
Allow dev to optionally set env vars

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -7,6 +7,10 @@ on:
         type: string
         description: "The name of the repository where the template is located"
         required: true
+      deployed-environment-variables:
+        type: string
+        description: "The environment variables to set for the lambda function on aws, set as mock values."
+        required: false
       region:
         type: string
         description: "The AWS region to deploy to"
@@ -118,6 +122,7 @@ jobs:
       image-name: ${{ needs.dev-build.outputs.registry }}/lambda-feedback-dev-chat:${{ needs.setup.outputs.chat_function_name }}
       function-name: ${{ needs.setup.outputs.chat_function_name }}
       region: ${{ inputs.region }}
+      deployed-environment-variables: ${{ inputs.deployed-environment-variables }}
     secrets:
       aws-access-key-id: ${{ secrets.aws-access-key-id }}
       aws-secret-key: ${{ secrets.aws-secret-key }}

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -20,6 +20,10 @@ on:
         description: "The AWS region to deploy to"
         default: "eu-west-2"
         required: false
+      deployed-environment-variables:
+        type: string
+        description: "The environment variables to set for the lambda function on aws, set as mock values."
+        required: false
     secrets:
       aws-access-key-id:
         description: "The AWS access key ID"
@@ -54,6 +58,7 @@ jobs:
           API_KEY: ${{ secrets.function-admin-api-key }}
           IMAGE_NAME: ${{ inputs.image-name }}
           FUNCTION_NAME: ${{ inputs.function-name }}
+          ENVIRONMENT_VARIABLES: ${{ inputs.deployed-environment-variables }}
         run: |
           curl -f --location --request POST "$BACKEND_API_URL/chat-function/ensure" \
           --header 'content-type: application/json' \
@@ -61,4 +66,5 @@ jobs:
               \"apiKey\": \"$API_KEY\",
               \"dockerImageUri\": \"$IMAGE_NAME\",
               \"functionName\": \"$FUNCTION_NAME\"
+              \"arguments\": \"$ENVIRONMENT_VARIABLES\"
           }"

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -65,6 +65,6 @@ jobs:
           --data-raw "{
               \"apiKey\": \"$API_KEY\",
               \"dockerImageUri\": \"$IMAGE_NAME\",
-              \"functionName\": \"$FUNCTION_NAME\"
-              \"arguments\": \"$ENVIRONMENT_VARIABLES\"
+              \"functionName\": \"$FUNCTION_NAME\",
+              \"arguments\": $ENVIRONMENT_VARIABLES
           }"

--- a/.github/workflows/main_deploy.yml
+++ b/.github/workflows/main_deploy.yml
@@ -7,6 +7,10 @@ on:
         type: string
         description: "The name of the repository where the template is located"
         required: true
+      deployed-environment-variables:
+        type: string
+        description: "The environment variables to set for the lambda function on aws, set as mock values."
+        required: false
       region:
         type: string
         description: "The AWS region to deploy to"
@@ -175,6 +179,7 @@ jobs:
       image-name: ${{ needs.prod-build.outputs.registry }}/lambda-feedback-prod-chat:${{ needs.setup.outputs.chat_function_name }}
       function-name: ${{ needs.setup.outputs.chat_function_name }}
       region: ${{ inputs.region }}
+      deployed-environment-variables: ${{ inputs.deployed-environment-variables }}
     secrets:
       aws-access-key-id: ${{ secrets.aws-access-key-id }}
       aws-secret-key: ${{ secrets.aws-secret-key }}


### PR DESCRIPTION
Allow developer to set the wanted environment variables directly through the Github workflows (such that variables are added to the AWS lambda with a mock value (that is later replaced by admin with the real secrets))

This code is called by the function main repo where the env variables are being set in the deploy stage of the workflow.